### PR TITLE
Faster snippet builder

### DIFF
--- a/sniper/Cargo.toml
+++ b/sniper/Cargo.toml
@@ -26,4 +26,5 @@ lazy_static= "1.4.0"
 serde = {version="1.0.115", features=["derive"]}
 toml = {version="0.5", features = ["preserve_order"]}#NOTE: will likely be removed soon, planning move to json for snippets
 directories = "3.0"
+priority_queue="1.1.1"
 umask="1.0.0"

--- a/sniper/Cargo.toml
+++ b/sniper/Cargo.toml
@@ -24,7 +24,6 @@ serde-tuple-vec-map={version="1.0.0"}
 regex= {version="1.4.6"}
 lazy_static= "1.4.0"
 serde = {version="1.0.115", features=["derive"]}
-toml = {version="0.5", features = ["preserve_order"]}#NOTE: will likely be removed soon, planning move to json for snippets
+toml = {version="0.5", features = ["preserve_order"]}#NOTE: still used for config
 directories = "3.0"
-priority_queue="1.1.1"
 umask="1.0.0"

--- a/sniper/src/main.rs
+++ b/sniper/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
     println!("{:#?}",sniper_session.rifle.snippets);
     println!("{:?}",sniper_session.config.languages["python"]);
     println!("{:#?}",sniper_session.snipe("python","if/elif/else"));
+    println!("{:#?}",sniper_session.snipe("python","if"));
     sniper_session.add_target("12345","test.py","python");
     
     //println!("{:?}",config)

--- a/sniper/src/rifle.rs
+++ b/sniper/src/rifle.rs
@@ -1,14 +1,14 @@
 #[macro_use]
 use lazy_static::lazy_static;
-use rayon::iter::{IntoParallelIterator,IndexedParallelIterator,ParallelIterator,IntoParallelRefIterator};
-use priority_queue::PriorityQueue;
-use crate::snippet::{Snippet,SnippetSet,Loader};
+use rayon::{iter::{IntoParallelIterator,ParallelIterator}};
+use crate::snippet::{Loader, Snippet, SnippetSet};
 use crate::snippetParser::{SnipComponent,SnippetBuildMetadata};
 
 use dashmap::DashMap;
 use regex::Regex;
 
-use std::collections::{HashMap};
+use core::{borrow, panic};
+use std::{borrow::Cow, collections::{HashMap, VecDeque}};
 use std::sync::{Arc,Mutex};
 //good artist copy, great artist steal
 //https://stackoverflow.com/questions/51344951/how-do-you-unwrap-a-result-on-ok-or-return-from-the-function-on-err
@@ -22,13 +22,7 @@ macro_rules! unwrap_or_return {
         }
     }
 }
-/*macro_rules! get_sub_str {
-    ( $slice:ident,$re:ident,$old_start:ident ) => {
-        let temp_indices=$re.find($slice);
-        let sub_str=((&$slice[temp_indices..temp_indices.end()]);
-        $old_start=temp_indices.end()
-    }
-}*/
+
 
 ///This struct stores snippets, tracks the sets in play, and handles all logic related to snippet management
 /// such as removal, and rebuilding the snippet
@@ -57,48 +51,64 @@ impl Rifle {
             snippet_set.push(snippet_key.to_owned());
         }
         self.snippet_sets.insert((language.into(),snip_set_name.into()),SnippetSet::new(snippet_set));
-        let mut buildmap=DashMap::with_capacity(snippet_set.len());
-        let q_guard=Arc::new(Mutex::new(PriorityQueue::with_capacity(snippet_set.len())));
+        
 
-        for snippet_name in snippet_set.par_iter(){
-            let snipbuild=self.parse_snippet(language.into(),snippet_name);
-            
-            let mut snipq=q_guard.lock().unwrap();
-
-            if let Some(P)= *snipq.get_priority(snippet_name){
-                *snipq.change_priority(snippet_name,P+1);
-            }else {
-                *snipq.push(snippet_name,0);
-            }
-            
-            for sub_name in snipbuild.sub_snippets.iter()
-                if let Some(P)= *snipq.get_priority(sub_name){
-                    *snipq.change_priority(sub_name,P+1);
-                }else {
-                    *snipq.push(sub_name,0)
-                }
-            buildmap.insert(snippet_name,snipbuild);
-        }
+        
         
         
     }
+
     pub fn unload(&mut self, language: &str, snip_set_to_drop: &str) {
         for snippet_key in self.snippet_sets[&(language.into(),snip_set_to_drop.into())].contents.iter(){
             self.snippets.remove(&(language.to_string(),snippet_key.to_string()));
         }
         self.snippet_sets.remove(&(language.into(),snip_set_to_drop.into()));
     }
+    
+    fn rebuild_snippets(&mut self, language: &str, snippet_name: String){
+        
+        let mut snippet_stack=VecDeque::new();
+        let mut build_stack=VecDeque::new();
+        snippet_stack.push_back(snippet_name);
+        println!("starting to parse");
+        while let Some(snip_name) = snippet_stack.pop_front(){
+            println!("starting parsing for {:?}",snip_name);
+   
+            let (snipbuild,sub_snips)=self.parse_snippet(language.into(),&snip_name);
+            
+            
+            (0..sub_snips.len()).into_iter().for_each(|i| {
+                if self.snippets.contains_key(&(language.into(),sub_snips[i].clone())){
+                    if self.snippets.get(&(language.into(),sub_snips[i].clone())).unwrap().requires_assembly{
+                        snippet_stack.push_back(sub_snips[i].clone());
+                    }
+                }
+            });
+            build_stack.push_back(snipbuild);
+            
+        }
+        println!("finished parsing,starting build process");
+        while let  Some(build_data) = build_stack.pop_back(){
+            
+            self.build_snippet(language, build_data);
+        }
+    }
 
     //TODO: probably need to change the output format
-    pub fn fire(&mut self, language: &str,snippet_name: &str) -> Option<Vec<String>> { 
-        if self.snippets.contains_key(&(language.to_string(),snippet_name.to_string())){
-            
+    pub fn fire(&mut self, language: &str,snippet_name: &str) -> Option<Vec<String>> {
+        let snippet_key=&(language.to_string(),snippet_name.to_string()); 
+        println!("{:?} requested",snippet_name);
+        if self.snippets.contains_key(snippet_key){
+            if self.snippets.get(snippet_key).unwrap().requires_assembly{
+                self.rebuild_snippets(language,snippet_name.into());
+            }
+            Some(self.snippets.get(snippet_key).unwrap().body.clone())
         } else {
             None
         }
     }
     
-    async fn parse_snippet(&self, language: &str,snippet_name: &str){
+    fn parse_snippet(&self, language: &str,snippet_name: &str)-> (SnippetBuildMetadata,Vec<String>){
         //NOTE: while having more than one mutable reference inside a dashmap can risk deadlocks when multithreading,
         //there is no risk associated with multiple immutable ones
         //therefor I'm splitting the snippet rebuild process into two parts: parse_snippet and build_snippet
@@ -110,27 +120,36 @@ impl Rifle {
             static ref snippet_finder: Regex = Regex::new("[[a-zA-Z0-9/]]+").unwrap();
             static ref snippet_args_finder: Regex = Regex::new(r"\(.*\)}").unwrap();
         }
-        let mut build_data=Vec::with_capacity(self.snippets.get(&(language.into(),snippet_name.to_string())).unwrap().body.len());
-        let mut sub_snippet_count=0;
-        let mut snippet_stack=Vec::new();
-        self.snippets.get(&(language.into(),snippet_name.to_string())).unwrap().body.into_par_iter().enumerate().for_each(|(line_index,line)| {
+        let snippet_key=&(language.into(),snippet_name.to_string());
+        let borrowed_body=Cow::from(self.snippets.get(snippet_key).unwrap().body.clone());
+        let mut build_data:Vec<Vec<SnipComponent>>=Vec::with_capacity(borrowed_body.len());
+        (0..borrowed_body.len()).into_iter().for_each(|i|{
+            build_data.push(Vec::new());
+        });
+        let mut build_data_guard:Arc<Mutex<Vec<Vec<SnipComponent>>>>=Arc::new(Mutex::new(build_data));
+        let mut stack_guard=Arc::new(Mutex::new(Vec::new()));
+        println!("\nborrowed_body {:?}\n",borrowed_body);
+        (0..borrowed_body.len()).into_par_iter().for_each(|(line_index)| {
+            let line = &borrowed_body[line_index];
             let mut line_data=Vec::new();
-            for sub_match in modification_needed.find_iter(&line.clone()){
+            for sub_match in modification_needed.find_iter(line){
                 let lead_char=line[sub_match.start()..sub_match.end()].chars().nth(0).unwrap();
 
                 match lead_char{
                     '$'=> {
+                        //println!("found tabstop at {:?}",&line[sub_match.start()..sub_match.end()]);
                         let indices=digit.find(&line[sub_match.start()..sub_match.end()]).unwrap();
                         line_data.push(SnipComponent::tabstop{start:sub_match.start()+indices.start(),end:sub_match.start()+indices.end()});
 
                     }
                     '@'=>{
-                        let indices=snippet_finder.find(&line[end..]).unwrap();
-                        let sub_snippet_name=&line[end+snippet_indices.start()..end+snippet_indices.end()];
-                        snippet_stack.push(sub_snippet_name);
-                        sub_snippet_count+=1;
+                        let indices=snippet_finder.find(&line[sub_match.end()..]).unwrap();
                         let sub_snippet_name=&line[sub_match.end()+indices.start()..sub_match.end()+indices.end()];
-                        line_data.push(SnipComponent::sub_snippet{start:sub_match.end()+indices.start(),end:sub_match.end()+indices.end(),name=sub_snippet_name});
+                        let mut snippet_stack=stack_guard.lock().unwrap();
+                        snippet_stack.push(sub_snippet_name.to_string());
+                        
+                        let sub_snippet_name=&line[sub_match.end()+indices.start()..sub_match.end()+indices.end()];
+                        line_data.push(SnipComponent::sub_snippet{start:sub_match.end()+indices.start(),end:sub_match.end()+indices.end(),name:sub_snippet_name.into()});
                     }
                     _=>{
                         panic!("Zoinks Scoob! That wasn't supposed to happen");
@@ -138,14 +157,81 @@ impl Rifle {
 
                 }
             }
-            build_data[line_index]=line_data;
+            println!("{:?}",line_data);
+            if !line_data.is_empty(){
+                let mut build_data=build_data_guard.lock().unwrap();
+                build_data[line_index]=line_data;
+            }
         });
+        //println!("{:?}",build_data);
 
-        new::SnippetBuildMetadata(snippet_name,sub_snippet_count)
+        let snippet_stack=stack_guard.lock().unwrap();
+        let build_data=Arc::try_unwrap(build_data_guard).unwrap().into_inner().unwrap();
+        println!("{:?}",build_data);
+        (SnippetBuildMetadata::new(snippet_name.to_string(),snippet_stack.len(),build_data),snippet_stack.clone())
     }
 
-    fn build_snippet(&mut self, language: &str, build_data: Vec<SnippetBuildMetadata>) {
+    fn build_snippet(&mut self, language: &str, build_data: SnippetBuildMetadata) {
+        let snippet_key=&(language.to_string(),build_data.name.clone());
 
+        let mut new_body:Vec<String>=Vec::with_capacity(build_data.body.len());
+        let old_body=Cow::from(self.snippets.get(snippet_key).unwrap().body.clone());
+        let zero: usize=0;
+        let mut sub_snippet=Vec::new();
+        let mut tabstops=Vec::new();
+        let mut offset=0;
+        let mut contains_raw_content=true;
+        println!("{:#?}",build_data);
+        (0..build_data.body.len()).for_each(|line_index| {
+            if build_data.body[line_index].is_empty(){
+                new_body.push(old_body[line_index].clone());
+            } else {
+                println!("{:?}",&build_data.body[line_index]);
+                for component_index in 0..build_data.body[line_index].len(){
+                    match &build_data.body[line_index][component_index]{
+                        SnipComponent::tabstop { start, end }=>{
+                            tabstops.push((line_index ,*start,*end));
+                            offset+=1; 
+                        }
+
+                        SnipComponent::sub_snippet { start, end, name }=>{
+                            sub_snippet= self.snippets.get(&(language.to_string(),name.clone())).unwrap().body.clone();
+                            let mut sub_stops= self.snippets.get(&(language.to_string(),name.clone())).unwrap().tabstops.clone();
+                            for stop_index in 0..sub_stops.len(){
+                                let (ref mut sub_line,sub_start,sub_end)=sub_stops[stop_index];
+                                let digit=(sub_snippet[*sub_line][sub_start..sub_end]).parse::<i32>().unwrap();
+                                sub_snippet[*sub_line].replace_range(sub_start..sub_end,&(digit+offset).to_string());
+                                *sub_line+=line_index;
+                            }
+                            //if *start==zero && end==&old_body[line_index].len(){
+                            new_body.append(&mut sub_snippet);
+                            contains_raw_content=false;
+                            //TODO: actually workout substring checking for raw content
+
+                            //} 
+                            offset+=sub_stops.len() as i32;
+                            tabstops.append(&mut sub_stops)
+                        }
+                        
+                        SnipComponent::metatabstop(_, _) => {}
+                        
+                    }
+                }
+                if contains_raw_content{
+                    new_body.push(old_body[line_index].clone());
+                }
+                contains_raw_content=true;
+
+            }
+        });
+        drop(old_body);
+        println!("\n new body created: {:?}",new_body);
+        println!("\n list of tabstops: {:?}",tabstops);
+        //println!("\n old body{:?}",self.snippets.get(&(language.to_string(),build_data.name.clone())).unwrap().body);
+        self.snippets.get_mut(snippet_key).unwrap().body=new_body;
+        self.snippets.get_mut(snippet_key).unwrap().tabstops=tabstops;
+        self.snippets.get_mut(snippet_key).unwrap().requires_assembly=false;
+        println!("snippet modified");
     }
     
     

--- a/sniper/src/rifle.rs
+++ b/sniper/src/rifle.rs
@@ -56,7 +56,7 @@ impl Rifle {
             snippet_set.push(snippet_key.to_owned());
         }
         self.snippet_sets.insert((language.into(),snip_set_name.into()),SnippetSet::new(snippet_set));
-        
+        for key in self.snippets.iter()
     }
     pub fn unload(&mut self, language: &str, snip_set_to_drop: &str) {
         for snippet_key in self.snippet_sets[&(language.into(),snip_set_to_drop.into())].contents.iter(){

--- a/sniper/src/snippet.rs
+++ b/sniper/src/snippet.rs
@@ -34,6 +34,8 @@ pub struct Snippet {
     actions: Vec<Actions>,
     #[serde(default = "assembly_required")]
     pub(crate) requires_assembly:bool,
+    #[serde(default="currently_empty")]
+    pub(crate) tabstops:Vec<(usize,usize,usize)>
 }
 
 fn default_snippet_type() -> SnippetTypes {
@@ -49,6 +51,9 @@ fn no_action() -> Vec<Actions> {
 }
 fn assembly_required() -> bool {
     true
+}
+fn currently_empty() -> Vec<(usize,usize,usize)> {
+    Vec::new()
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/sniper/src/snippetParser.rs
+++ b/sniper/src/snippetParser.rs
@@ -1,32 +1,30 @@
 
+#[derive(Debug)]
 pub(crate) enum SnipComponent {
-    tabstop {start: u32, end: u32},
+    tabstop {start: usize, end: usize},
     metatabstop(u32,u32),
-    sub_snippet{start: u32,end: u32, name: String},
+    sub_snippet{start: usize,end: usize, name: String},
 }
 
 pub(crate) struct BuiltSnippetMetadata {
     //subsnippet_tabstops: Hashmap<name:string,tabstops:vec<(u32,u32,u32)>?
-    tabstops: Vec<(u32,u32,u32)>
+    tabstops: Vec<(usize,usize,usize)>
 
 }
-
+#[derive(Debug)]
 pub(crate) struct SnippetBuildMetadata {
-    name: String,
-    sub_snippet_count: u32,
-    tabstops: Vec<(u32,u32,u32)>,
-    body: Vec<Vec<SnipComponent>>,
-    sub_snippets:Vec<String>
+    pub(crate)name: String,
+    pub(crate)sub_snippet_count: usize,
+    //pub(crate)tabstops: Vec<(usize,usize,usize)>,
+    pub(crate)body: Vec<Vec<SnipComponent>>,
 }
 
 impl SnippetBuildMetadata {
-    pub(crate) fn new(name:String,sub_snip_count:u32,sub_snips: Vec<String>)->Self {
+    pub(crate) fn new(name: String,sub_snip_count:usize,body: Vec<Vec<SnipComponent>>)->Self {
         Self {
             name: name,
             sub_snippet_count: sub_snip_count,
-            tabstops: Vec::new(),
-            body: Vec::new(),
-            sub_snippets: sub_snips,
+            body: body,
         }
     }
 }


### PR DESCRIPTION
I seperated the function for recursively rebuilding snippets into 2 parts: 
parsing which produced build data for things like locations of subsnippets and tabstops, this process pushes the build data into a stack so that subsnippets are built first (if those snippets haven't been parsed before).

in the building phase elements are then accessed by directly by slice indexes, and tabstops indexes are collected and appended to the current snippet. allowing for fast builds of the current snippet and any snippet that depends on the current snippet built in the future. to give an example of the output this is the result of requesting `if/elif/else` followed by `if`
```
"if/elif/else" requested
starting parsing snippet: "if/elif/else"
starting parsing snippet: "if"
starting parsing snippet: "else"
starting parsing snippet: "elif"
finished parsing,starting build process
SnippetBuildMetadata {
    name: "elif",
    sub_snippet_count: 0,
    body: [
        [
            tabstop {
                start: 7,
                end: 8,
            },
        ],
        [
            tabstop {
                start: 3,
                end: 4,
            },
        ],
    ],
}
SnippetBuildMetadata {
    name: "else",
    sub_snippet_count: 0,
    body: [
        [],
        [
            tabstop {
                start: 3,
                end: 4,
            },
        ],
    ],
}
SnippetBuildMetadata {
    name: "if",
    sub_snippet_count: 0,
    body: [
        [
            tabstop {
                start: 5,
                end: 6,
            },
        ],
        [
            tabstop {
                start: 3,
                end: 4,
            },
        ],
    ],
}
SnippetBuildMetadata {
    name: "if/elif/else",
    sub_snippet_count: 3,
    body: [
        [
            sub_snippet {
                start: 1,
                end: 3,
                name: "if",
            },
        ],
        [
            sub_snippet {
                start: 1,
                end: 5,
                name: "elif",
            },
        ],
        [
            sub_snippet {
                start: 1,
                end: 5,
                name: "else",
            },
        ],
    ],
}

"if/elif/else" returned:
Some(
    [
        "if ${1:expression}:",
        "\t${2:pass}",
        "elif ${3:expression}:",
        "\t${4:pass}",
        "else:",
        "\t${5:pass}",
    ],
)
"if" requested

"if" returned:
Some(
    [
        "if ${1:expression}:",
        "\t${2:pass}",
    ],
)
```